### PR TITLE
Correct time stamp formatting error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ nbactions.xml
 #################
 
 .idea
+build
+deploy-test
+/CloudSession-Templates.tar.gz

--- a/Failures.py
+++ b/Failures.py
@@ -99,6 +99,11 @@ def screen_name_already_in_use(screen_name):
 
 
 def rate_exceeded(time):
+    """
+      Service requested to frequently.
+
+      time - string representing the date and time the service will be available again
+    """
     logging.debug('Failures: Rate exceeded')
     return {
                'success': False,

--- a/app/RateLimiting/controllers.py
+++ b/app/RateLimiting/controllers.py
@@ -1,5 +1,4 @@
 import logging
-import time
 
 import Failures
 from app import db, app
@@ -54,7 +53,7 @@ class ConsumeSingle(Resource):
 
         if not result:
             db.session.commit()
-            return Failures.rate_exceeded(time.strptime(next_time, '%c'))
+            return Failures.rate_exceeded(next_time.strftime("%Y-%m-%d %H:%M:%S"))
 
         db.session.commit()
 
@@ -104,7 +103,7 @@ class ConsumeMultiple(Resource):
 
         if not result:
             db.session.commit()
-            return Failures.rate_exceeded(time.strptime(next_time, '%c'))
+            return Failures.rate_exceeded(next_time.strftime("%Y-%m-%d %H:%M:%S"))
 
         db.session.commit()
 

--- a/app/RateLimiting/services.py
+++ b/app/RateLimiting/services.py
@@ -40,7 +40,7 @@ def consume_tokens(id_user, bucket_type, token_count):
 
     bucket.content = bucket.content - token_count
     bucket.timestamp = datetime.datetime.now()
-    return True, bucket.timestamp
+    return True,  bucket.timestamp
 
 
 def has_sufficient_tokens(id_user, bucket_type, token_count):
@@ -70,6 +70,6 @@ def has_sufficient_tokens(id_user, bucket_type, token_count):
         milliseconds_till_enough = (token_count - old_bucket_content) * bucket_stream_frequency
         date_when_enough = bucket.timestamp + datetime.timedelta(milliseconds=milliseconds_till_enough)
         # Log and return or throw error
-        return False
+        return False, date_when_enough
 
     return True

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -23,7 +23,9 @@ from flask.ext.mail import Mail
 from raven.contrib.flask import Sentry
 
 app = Flask(__name__)
-version = "1.1.1"
+
+# Application version (major,minor,patch-level)
+version = "1.1.2"
 db = None
 
 # Load basic configurations


### PR DESCRIPTION
When the Cloud Session service fails a compile request due to insufficient tokens, it is supposed to return a string to client, indicating the date/time the next token will be available. 