### PR TITLE
Update Confirm template

### DIFF
--- a/templates/en/confirm/blocklyprop/plain.mustache
+++ b/templates/en/confirm/blocklyprop/plain.mustache
@@ -1,9 +1,9 @@
 {{! This is the text body of the email}}
 Dear {{screenname}},
 
-Please go to http://{{blocklyprop-host}}//blockly/confirm?locale={{locale}}&email={{registrant-email}}&token={{token}} to confirm your email address.
+Please go to http://{{blocklyprop-host}}/blockly/confirm?locale={{locale}}&email={{registrant-email}}&token={{token}} to confirm your email address.
 
-If the url does not work, please go to http://{{blocklyprop-host}}//blockly/confirm, then enter your email address ({{email}}), and the token: {{token}}
+If the url does not work, please go to http://{{blocklyprop-host}}/blockly/confirm, then enter your email address ({{email}}), and the supplied token: {{token}}
 
 
 The Parallax team

--- a/templates/en_US/confirm/blocklyprop/plain.mustache
+++ b/templates/en_US/confirm/blocklyprop/plain.mustache
@@ -3,7 +3,6 @@ Dear {{screenname}},
 
 Please go to http://{{blocklyprop-host}}/blockly/confirm?locale={{locale}}&email={{email}}&token={{token}} to confirm your email address.
 
-If the url does not work, please go to http://{{blocklyprop-host}}/blockly/confirm and enter your email address and the token: {{token}}
-
+If the url does not work, please go to http://{{blocklyprop-host}}/blockly/confirm and enter your email address and the supplied token: {{token}}
 
 The Parallax team


### PR DESCRIPTION
Update the us and en_us versions of the confirm template to remove an extraneous '/' from the URL.