### PR TITLE
Add template variables to suplement plus sign in some email addresses

### DIFF
--- a/app/Email/services.py
+++ b/app/Email/services.py
@@ -99,6 +99,25 @@ def send_email_template_to_address(recipient, template, server, locale, params=N
     params['email'] = recipient
     params['locale'] = locale
 
+    # Create a URI-friendly version of the email addresses
+    params['email-uri'] = _convert_email_uri(params['email'])
+    logging.info("Email address %s converted to %s",
+                 params['email'],
+                 params['email-uri']
+                 )
+
+    params['registrant-email-uri'] = _convert_email_uri(params['registrant-email'])
+    logging.info("Registrant email address %s converted to %s",
+                 params['registrant-email'],
+                 params['registrant-email-uri']
+                 )
+
+    params['sponsor-email-uri'] = _convert_email_uri(params['sponsoremail'])
+    logging.info("Sponsor email address %s converted to %s",
+                 params['sponsoremail'],
+                 params['sponsor-email-uri']
+                 )
+
     # Read templates
     (subject, plain, rich) = _read_templates(template, server, locale, params)
     # Add error checking here to detect any issues with parsing the template.
@@ -180,3 +199,19 @@ def _read_template(template, server, locale, part, params, none_if_missing=False
             return None
         else:
             return 'Template missing'
+
+
+def _convert_email_uri(email):
+    """
+    Evaluate email address and replace any plus signs that may appear in the
+    portion of the address prior to the '@' with the literal '%2B'.
+
+    Standard web servers will convert any plus ('+') symbol to a space (' ')
+    anywhere where they may appear in the URL. This will allow functions upstream
+    to create a URI that contains an email address that, when submitted to a
+    server, will not be replaced with a space character.
+    """
+    if "+" in email:
+        return email.replace("+", "%2B")
+    else:
+        return email

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -24,11 +24,15 @@ from raven.contrib.flask import Sentry
 app = Flask(__name__)
 
 # Application version (major,minor,patch-level)
-version = "1.1.3"
+version = "1.1.4"
 
 """
 Change Log
 
+1.1.4       Add code to convert plus signs located the the username portion
+            of an email address to a '%2B'when the email address is embedded
+            in a URL.
+            
 1.1.3       Added documentation around the user account registration process.
 
 """

--- a/templates/en/confirm-parent/blocklyprop/plain.mustache
+++ b/templates/en/confirm-parent/blocklyprop/plain.mustache
@@ -37,10 +37,7 @@ Getting Started with BlocklyProp for more information.
 
 Confirm account registration:
 Copy and paste into your browser
-http://{{blocklyprop-host}}/blockly/confirm?locale={{locale}}&email={{registrant-email}}&token={{token}} to confirm your email address.
-
-If the above link is unable to complete your registration, please go to
-http://{{blocklyprop-host}}/blockly/confirm and enter your email address and the token: {{token}}
+http://{{blocklyprop-host}}/blockly/confirm?locale={{locale}}&email={{registrant-email-uri}}&token={{token}} to confirm your email address.
 
 If the above link is unable to complete the registration, please go to
 http://{{blocklyprop-host}}/blockly/confirm and enter your email address and the token: {{token}}

--- a/templates/en/confirm-teacher/blocklyprop/plain.mustache
+++ b/templates/en/confirm-teacher/blocklyprop/plain.mustache
@@ -12,10 +12,10 @@ If this is your student, please confirm the registration by copying the link bel
 your browser or by navigating to the second link and confirming the student's email address.
 
 Copy and paste into your browser
-http://{{blocklyprop-host}}/blockly/confirm?locale={{locale}}&email={{registrant-email}}&token={{token}} to confirm your email address.
+http://{{blocklyprop-host}}/blockly/confirm?locale={{locale}}&email={{registrant-email-uri}}&token={{token}} to confirm your email address.
 
 If the above link is unable to complete your registration, please go to
-http://{{blocklyprop-host}}/blockly/confirm and enter your student's email address ({{registrant-email}}) and the token: {{token}}
+http://{{blocklyprop-host}}/blockly/confirm and enter your student's email address ({{registrant-email-uri}}) and the token: {{token}}
 
 Regards,
 

--- a/templates/en/confirm/blocklyprop/plain.mustache
+++ b/templates/en/confirm/blocklyprop/plain.mustache
@@ -1,9 +1,9 @@
 {{! This is the text body of the email}}
 Dear {{screenname}},
 
-Please go to http://{{blocklyprop-host}}/blockly/confirm?locale={{locale}}&email={{registrant-email}}&token={{token}} to confirm your email address.
+Please go to http://{{blocklyprop-host}}/blockly/confirm?locale={{locale}}&email={{registrant-email-uri}}&token={{token}} to confirm your email address.
 
-If the url does not work, please go to http://{{blocklyprop-host}}/blockly/confirm, then enter your email address ({{email}}), and the supplied token: {{token}}
+If the url does not work, please go to http://{{blocklyprop-host}}/blockly/confirm, then enter your email address ({{email-uri}}), and the supplied token: {{token}}
 
 
 The Parallax team

--- a/templates/en/reset-coppa/blocklyprop/plain.mustache
+++ b/templates/en/reset-coppa/blocklyprop/plain.mustache
@@ -6,7 +6,7 @@ Hello,
 
 The BlocklyProp web site has received a request to reset the password for user '{{screenname}}'.
 
-If this request was made by you, please go to http://{{blocklyprop-host}}/blockly/reset?locale={{locale}}&email={{registrant-email}}&token={{token}} to reset your password now.
+If this request was made by you, please go to http://{{blocklyprop-host}}/blockly/reset?locale={{locale}}&email={{registrant-email-uri}}&token={{token}} to reset your password now.
 
 If the url does not work, please go to http://{{blocklyprop-host}}/blockly/reset and use the token: {{token}}
 

--- a/templates/en/reset/blocklyprop/plain.mustache
+++ b/templates/en/reset/blocklyprop/plain.mustache
@@ -2,7 +2,7 @@ Hello,
 
 The BlocklyProp web site has received a request to reset the password for user '{{screenname}}'.
 
-If this request was made by you, please go to http://{{blocklyprop-host}}/blockly/reset?locale={{locale}}&email={{registrant-email}}&token={{token}} to reset your password now.
+If this request was made by you, please go to http://{{blocklyprop-host}}/blockly/reset?locale={{locale}}&email={{registrant-email-uri}}&token={{token}} to reset your password now.
 
 If the url does not work, please go to http://{{blocklyprop-host}}/blockly/reset and use the token: {{token}}
 

--- a/templates/en_US/confirm-parent/blocklyprop/plain.mustache
+++ b/templates/en_US/confirm-parent/blocklyprop/plain.mustache
@@ -11,21 +11,45 @@
 }}
 Hello,
 
-A person under age 13 has requested a new account on the Parallax BlocklyProp web site http://{{blocklyprop-host}} under the screen name {{screenname}}. In the request, your email address was provided as the parent or guardian of the requester.
+Someone, perhaps your child, has requested a new account on the Parallax
+BlocklyProp web site (http://blockly.parallax.com) under the screen name
+{{screenname}}. When the account was created, your email address was
+submitted as the parent or guardian of the registrant. If this is incorrect,
+please accept our apologies. There is nothing more you need to do. The
+request will automatically expire.
 
-BlocklyProp is a free, online programming tool designed for education. See Getting Started with BlocklyProp for more information.
+Why are we sending this? In the US, the federal Children's Online Privacy
+Protection Act, known as COPPA, requires that we communicate with a parent
+or guardian if the person registering an BlocklyProp account is under the
+age of 13. The Act allows you to decline the registration request. If you
+choose this option, we will immediately remove the registration information
+and the associated account. If you choose to confirm the the request and
+activate the account, you may close the account at any time by clicking on
+the link provided below. This action will close the account and remove any
+projects that are associated with the account.
 
-Why are we sending this? In the US, the federal Children's Online Privacy Protection Act (COPPA) requires that we communicate with a parent or guardian of any person under age 13 that requests a BlocklyProp account. A full copy of our Child Privacy Policy is available online at: http://{{blocklyprop-host}}/blockly/privacy-policy
+A full copy of our Child Privacy Policy is available online at:
+http://{{blocklyprop-host}}/blockly/child-privacy-policy
 
-To complete your child's account registration, please copy and past this link into your browser to confirm your email address:
+BlocklyProp is a free, online programming tool designed for education. See
+Getting Started with BlocklyProp for more information.
 
-http://{{blocklyprop-host}}/blockly/confirm?locale={{locale}}&email={{registrant-email}}&token={{token}} to confirm your email address.
 
-If the above link is unable to complete the registration, please go to http://{{blocklyprop-host}}/blockly/confirm and enter your email address and the token: {{token}}
+Confirm account registration:
+Copy and paste into your browser
+http://{{blocklyprop-host}}/blockly/confirm?locale={{locale}}&email={{registrant-email-uri}}&token={{token}} to confirm your email address.
 
-If you do NOT want to complete your child's account registration, you need do nothing more; this confirmation request will automatically expire in 7 days and the account will not be created.
+If the above link is unable to complete the registration, please go to
+http://{{blocklyprop-host}}/blockly/confirm and enter your email address and the token: {{token}}
 
-If you do complete your child's account registration, you may close the account in the future. Email a request for closure and your child's screen name to blocklyadmin@parallax.com. We will confirm your request and then close the account and remove any projects that are associated with the account.
+If you do NOT want to complete your child's account registration, you need do
+nothing more; this confirmation request will automatically expire in 7 days and
+the account will not be created.
+
+If you do complete your child's account registration, you may close the account
+in the future. Email a request for closure and your child's screen name to
+blocklyadmin@parallax.com. We will confirm your request and then close the account
+and remove any projects that are associated with the account.
 
 Regards,
 

--- a/templates/en_US/confirm-teacher/blocklyprop/plain.mustache
+++ b/templates/en_US/confirm-teacher/blocklyprop/plain.mustache
@@ -12,10 +12,10 @@ If this is your student, please confirm the registration by copying the link bel
 your browser or by navigating to the second link and confirming the student's email address.
 
 Copy and paste into your browser
-http://{{blocklyprop-host}}/blockly/confirm?locale={{locale}}&email={{registrant-email}}&token={{token}} to confirm your email address.
+http://{{blocklyprop-host}}/blockly/confirm?locale={{locale}}&email={{registrant-email-uri}}&token={{token}} to confirm your email address.
 
 If the above link is unable to complete your registration, please go to
-http://{{blocklyprop-host}}/blockly/confirm and enter your student's email address ({{registrant-email}}) and the token: {{token}}
+http://{{blocklyprop-host}}/blockly/confirm and enter your student's email address ({{registrant-email-uri}}) and the token: {{token}}
 
 Regards,
 

--- a/templates/en_US/confirm/blocklyprop/plain.mustache
+++ b/templates/en_US/confirm/blocklyprop/plain.mustache
@@ -1,8 +1,9 @@
 {{! This is the text body of the email}}
 Dear {{screenname}},
 
-Please go to http://{{blocklyprop-host}}/blockly/confirm?locale={{locale}}&email={{email}}&token={{token}} to confirm your email address.
+Please go to http://{{blocklyprop-host}}/blockly/confirm?locale={{locale}}&email={{registrant-email-uri}}&token={{token}} to confirm your email address.
 
-If the url does not work, please go to http://{{blocklyprop-host}}/blockly/confirm and enter your email address and the supplied token: {{token}}
+If the url does not work, please go to http://{{blocklyprop-host}}/blockly/confirm, then enter your email address ({{email-uri}}), and the supplied token: {{token}}
+
 
 The Parallax team

--- a/templates/en_US/reset-coppa/blocklyprop/plain.mustache
+++ b/templates/en_US/reset-coppa/blocklyprop/plain.mustache
@@ -6,7 +6,7 @@ Hello,
 
 The BlocklyProp web site has received a request to reset the password for user '{{screenname}}'.
 
-If this request was made by you, please go to http://{{blocklyprop-host}}/blockly/reset?locale={{locale}}&email={{registrant-email}}&token={{token}} to reset your password now.
+If this request was made by you, please go to http://{{blocklyprop-host}}/blockly/reset?locale={{locale}}&email={{registrant-email-uri}}&token={{token}} to reset your password now.
 
 If the url does not work, please go to http://{{blocklyprop-host}}/blockly/reset and use the token: {{token}}
 

--- a/templates/en_US/reset/blocklyprop/plain.mustache
+++ b/templates/en_US/reset/blocklyprop/plain.mustache
@@ -2,7 +2,7 @@ Hello,
 
 The BlocklyProp web site has received a request to reset the password for user '{{screenname}}'.
 
-If this request was made by you, please go to http://{{blocklyprop-host}}/blockly/reset?locale={{locale}}&email={{registrant-email}}&token={{token}} to reset your password now.
+If this request was made by you, please go to http://{{blocklyprop-host}}/blockly/reset?locale={{locale}}&email={{registrant-email-uri}}&token={{token}} to reset your password now.
 
 If the url does not work, please go to http://{{blocklyprop-host}}/blockly/reset and use the token: {{token}}
 


### PR DESCRIPTION
The plus sign '+' is a legal character in an email address. However, if an email containing the plus sign is embedded in a URL, the web server interprets the plus sign as a space character and this changes the meaning of the data embedded in the URL

This patch creates three new mustache template variables to represent email addresses that are used within URL constructs. These are:

email-uri  - email address of the account holder
registrant-email-uri  - email address of the account registrant
sponsor-email-uri  - email address of the account sponsor. Used in COPPA restricted accounts.
