### PR TITLE
Null email address causes Null Pointer exception

### DIFF
--- a/app/Email/services.py
+++ b/app/Email/services.py
@@ -211,7 +211,8 @@ def _convert_email_uri(email):
     to create a URI that contains an email address that, when submitted to a
     server, will not be replaced with a space character.
     """
-    if "+" in email:
-        return email.replace("+", "%2B")
-    else:
-        return email
+    if email is not None:
+        if "+" in email:
+            return email.replace("+", "%2B")
+
+    return email

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -24,10 +24,13 @@ from raven.contrib.flask import Sentry
 app = Flask(__name__)
 
 # Application version (major,minor,patch-level)
-version = "1.1.4"
+version = "1.1.5"
 
 """
 Change Log
+
+1.1.5       Refactor _convert_email_uri(email) to properly handle a null
+            email address.
 
 1.1.4       Add code to convert plus signs located the the username portion
             of an email address to a '%2B'when the email address is embedded


### PR DESCRIPTION
A change made in version 1.1.14 to correct a URI issue introduced code that did not test for null data before operating on it. This error cascaded to the BlocklyProp service in the form a Null Pointer Exception.

The patch simply verifies that the email parameter actually contains data before attempting string manipulation on it.