### PR TITLE
Add logging details for authetication errors.

### DIFF
--- a/Failures.py
+++ b/Failures.py
@@ -12,7 +12,7 @@ def unknown_user_id(id_user):
 
 
 def unknown_user_email(email):
-    logging.debug('Failures: Unknown user: %s', email)
+    logging.debug('Failures: Unknown user email: %s', email)
     return {
                'success': False,
                'message': 'Unknown user',
@@ -41,8 +41,8 @@ def email_already_in_use(email):
            }, 500
 
 
-def email_not_confirmed():
-    logging.debug('Failures: Email not confirmed')
+def email_not_confirmed(email):
+    logging.debug('Failures: Email %s not confirmed', email)
     return {
                'success': False,
                'message': 'Email not confirmed',
@@ -50,8 +50,8 @@ def email_not_confirmed():
            }, 401
 
 
-def user_blocked():
-    logging.debug('Failures: User blocked')
+def user_blocked(email):
+    logging.debug('Failures: User %s blocked', email)
     return {
                'success': False,
                'message': 'User is blocked',
@@ -113,8 +113,8 @@ def rate_exceeded(time):
            }, 500
 
 
-def wrong_password():
-    logging.debug('Failures: Wrong password')
+def wrong_password(email):
+    logging.debug('Failures: Wrong password for %s', email)
     return {
                'success': False,
                'message': 'Wrong password',

--- a/app/Authenticate/controllers.py
+++ b/app/Authenticate/controllers.py
@@ -41,9 +41,9 @@ class AuthenticateLocalUser(Resource):
         if user is None:
             return Failures.unknown_user_email(email)
         if not user.confirmed:
-            return Failures.email_not_confirmed()
+            return Failures.email_not_confirmed(email)
         if user.blocked:
-            return Failures.user_blocked()
+            return Failures.user_blocked(email)
         if user.auth_source != 'local':
             return Failures.wrong_auth_source(user.auth_source)
 
@@ -53,11 +53,11 @@ class AuthenticateLocalUser(Resource):
         if not user_services.check_password(user.id, password):
             rate_limiting_services.consume_tokens(user.id, 'failed-password', 1)
             db.session.commit()
-            return Failures.wrong_password()
+            return Failures.wrong_password(email)
 
         db.session.commit()
 
-        logging.info('Authenticate-controller: Authenticate: success: %s', user.id)
+        logging.info('Authenticate-controller: Authenticate: success: %s', email)
 
         return {'success': True, 'user': {
             'id': user.id,

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -24,10 +24,12 @@ from raven.contrib.flask import Sentry
 app = Flask(__name__)
 
 # Application version (major,minor,patch-level)
-version = "1.1.5"
+version = "1.1.6"
 
 """
 Change Log
+
+1.1.6       Add email address detail for various authentication failures
 
 1.1.5       Refactor _convert_email_uri(email) to properly handle a null
             email address.


### PR DESCRIPTION
Some authentication issues were logged without any detail that would provide context. This patch addresses that issue.
